### PR TITLE
Use DNS to verify DNS

### DIFF
--- a/cloudfront-ssl/Makefile
+++ b/cloudfront-ssl/Makefile
@@ -1,7 +1,11 @@
 DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 DomainName=takkyuuplayer.com
 ValidationDomain=takkyuuplayer.com
+HostedZoneId=$(shell aws route53 list-hosted-zones-by-name --dns-name ${ValidationDomain} | jq -r '.HostedZones[0].Id' | sed -e 's|/hostedzone/||g')
 StackName=ssl-$(shell echo ${DomainName} | sed -e 's/\./-/g')
+
+# To use an ACM certificate with Amazon CloudFront, you must request or import the certificate in the US East (N. Virginia) region.
+# https://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html
 
 confirm:
 	aws cloudformation deploy \
@@ -9,15 +13,15 @@ confirm:
 		--no-execute-changeset \
 		--stack-name ${StackName} \
 		--template-file template.cf.yml \
-		--parameter-overrides DomainName=${DomainName} ValidationDomain=${ValidationDomain}
+		--parameter-overrides DomainName=${DomainName} ValidationDomain=${ValidationDomain} HostedZoneId=${HostedZoneId}
 
 deploy:
-	@echo "You will get email in https://docs.aws.amazon.com/acm/latest/userguide/setup-email.html"
+	@echo "When HostedZoneId = null, you will get email in https://docs.aws.amazon.com/acm/latest/userguide/setup-email.html"
 	aws cloudformation deploy \
 		--region us-east-1 \
 		--stack-name ${StackName} \
 		--template-file template.cf.yml \
-		--parameter-overrides DomainName=${DomainName} ValidationDomain=${ValidationDomain}
+		--parameter-overrides DomainName=${DomainName} ValidationDomain=${ValidationDomain} HostedZoneId=${HostedZoneId}
 
 help:
 	@cat Makefile

--- a/cloudfront-ssl/template.cf.yml
+++ b/cloudfront-ssl/template.cf.yml
@@ -9,11 +9,25 @@ Parameters:
   ValidationDomain:
     Type: String
     Description: FQDN
+  HostedZoneId:
+    Type: String
+    Description: HostedZoneId for the ValidationDomain
+Conditions:
+  HasHostedZoneId: !Not [!Equals [!Ref HostedZoneId, "null"]]
 Resources:
   SSLCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
       DomainName: !Ref DomainName
       DomainValidationOptions:
-        - DomainName: !Ref DomainName
-          ValidationDomain: !Ref ValidationDomain
+        - Fn::If:
+            - HasHostedZoneId
+            - DomainName: !Ref DomainName
+              HostedZoneId: !Ref HostedZoneId
+            - DomainName: !Ref DomainName
+              ValidationDomain: !Ref ValidationDomain
+      ValidationMethod:
+        Fn::If:
+          - HasHostedZoneId
+          - "DNS"
+          - "Email"


### PR DESCRIPTION
* [\[アップデート\] CloudFormation で AWS Certificate Manager のDNS検証を自動化できるようになりました \| Developers\.IO](https://dev.classmethod.jp/articles/acm-extends-automation-certificate-issuance-via-cloudformation/)
* [AWS::CertificateManager::Certificate \- AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html)